### PR TITLE
Jenkinsfile: post build tasks. README.md: Jenkins settings. GitHub settings.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,22 +1,27 @@
 pipeline {
     agent any
     stages {
-        stage("Build") {
-            steps {
-                sh "./gradlew build"
-            }
-        }
-        stage("Test") {
-            steps {
-                sh "./gradlew check"
-            }
+        stage("No-op") {
+            sh "ls"
         }
     }
 
     post {
         always {
-            junit "build/reports/**/*.xml"
-            archiveArtifacts artifacts: "build/libs/**/*.jar", fingerprint: true
+            echo "One way or another, I have finished"
+            deleteDir() /* cleanup the pipeline's workspace */
+        }
+        success {
+            echo "I succeeded!"
+        }
+        unstable {
+            echo "I'm unstable!"
+        }
+        failure {
+            echo "I failed!"
+        }
+        changed {
+            echo "Things were different before!"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,9 @@ pipeline {
     agent any
     stages {
         stage("No-op") {
-            sh "ls"
+            steps {
+                sh "ls"
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # CICD Demo
 
-Create a branch protection rule to only allow merging to the main branch through Pull Request
+GitHub settings:
 
-Test branch protection rule
+- Create a branch protection rule to only allow merging to the main branch through Pull Request. Remember to also enable the rule "Do not allow bypassing the above settings"
+- Test branch protection rule. 
 
-Remember to also enable the rule "Do not allow bypassing the above settings"
+Jenkins settings:
+- Manage Jenkins - System - "Github API usage rate limiting strategy": "Throttle at/near rate limit"
+- M1-Pipeline - Configuration - "Discover branches": "All branches"
+


### PR DESCRIPTION
# About the Pull Request

## README file

### Jenkins settings

#### GitHub API usage rate limit strategy

By default, Jenkins evenly spread API requests to GitHub API. This behavior will cause the builds to sleep for a few minutes. We don't want to wait that long. 

So, we asked Jenkins to throttle when we're near the GitHub API rate limit. For that, we set the "GitHub API usage rate limit strategy" to "Throttle at/near rate limit".

#### Branches discovery

By default, Jenkins doesn't build the branch in a Pull Request. For example, the branch `cleanup-n-notifications` in this Pull Request won't be built. We don't want this behavior as if we commit/push new changes after creating Pull Request to the branch, we want to make sure these new changes don't break the build.

So, we set "Discover branches" to "All branches"

## Jenkinsfile

Nothing special to note for the Jenkinsfile, this section is just for the sake of completeness.